### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/reference.md
+++ b/en/reference.md
@@ -5,14 +5,20 @@ This document contains the following:
 * [Menu Description](/Dev%20Tools/Deploy/en/reference/#menu-description)
 * [Functional Description](/Dev%20Tools/Deploy/en/reference/#functional-description)
 
+<a id="menu-description"></a>
+
 ## Menu Description 
 
 ![deploy_ref_01_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_01_2018.png)
+
+<a id="artifact-menu"></a>
 
 ### 1. Artifact Menu
 
 It is the basic configuration unit of Deploy, to manage deployment. 
 Created artifacts are displayed on the list, on top of the page. 
+
+<a id="deployment-menu"></a>
 
 ### 2. Deployment Menu 
 
@@ -28,6 +34,8 @@ A scenario is composed of Jenkins-CLI template, binary deployment, and file depl
 * Select Server Group and Scenario for Deployment 
 * Concurrent/Individual Server Deployment within Server Group 
 * Detail deployment information, described on the deployment note, is available on View Result of the **Deployment History** tab. 
+
+<a id="deployment-option"></a>
 
 #### Deployment Option 
 
@@ -57,6 +65,8 @@ Deploy concurrently or individually to servers within a specified server group.
 * **Non-Suspension**
     * Scenario execution continues, regardless of errors.
 
+<a id="view-current-deployment-status"></a>
+
 #### View Current Deployment Status 
 
 You can check progress of scenario which is under deployment. 
@@ -65,6 +75,8 @@ You can check progress of scenario which is under deployment.
 
 * Click a deployment item at the header which shows by clicking an an artifact under deployment.
 * Click 'deploying' status on the deployment history page. 
+
+<a id="deployment-history"></a>
 
 ### Deployment History 
 You can see the detailed information on distribution history, settings, and notes.
@@ -93,6 +105,8 @@ The searched distribution history can be downloaded in an Excel file.
     * When the **Download** button is clicked while the **Exclude Histories Without Binary File** option is selected
     ![deploy_ref_06_2021.png](https://static.toastoven.net/prod_tcdeploy/reference/deploy_ref_06_2021.png)
 
+<a id="binary-group"></a>
+
 ### Binary Group 
 
 On the **Binary Group** tab, binaries are managed by group.  
@@ -109,6 +123,8 @@ Applicable to categorize binaries deployed for each server tool, such as Develop
 * You can set the auto delete policy for the binary group from the auto delete settings.
     * If you leave each item in the auto delete setting empty and create a binary group, the auto delete setting will not be applied.
 
+<a id="server-group"></a>
+
 ### Server Group 
 
 Deployment target servers can be managed by group. 
@@ -119,6 +135,8 @@ Based on the phase attribute, it is applicable to categorize server tool, such a
 * Group or server information can be modified. 
 * Scenario for each group can be configured. 
 
+<a id="adding-server-group"></a>
+
 #### Adding Server Group 
 
 ![deploy_ref_08_202402.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_08_202402.png)
@@ -128,6 +146,8 @@ Based on the phase attribute, it is applicable to categorize server tool, such a
     * Select OS and specify Shell Type: select from the list or enter one, directly. 
     * Select a server tool for Phase: choose NONE, if you don't need to specify. 
     * Click **Create**. 
+
+<a id="addingdeleting-server-information"></a>
 
 #### Adding/Deleting Server Information 
 
@@ -163,19 +183,37 @@ Server information can be added or deleted from **Create (Modify) Server Group**
 * Click the server to delete and click the **Delete Selected** on the left top.
 * Click **Create**: to modify, click **Modify**. 
 
+<a id="auto-scale-group-addition"></a>
+
+#### Auto Scale Group Addition
+
+<!-- TODO: translate body -->
+
+##### Scale-out Scenario Addition
+
+<!-- TODO: translate body -->
+
+<a id="resources"></a>
+
 ### Resources 
 
 Resources can be managed on the page, by creating, uploading, or modifying files; change history can also be found. 
 
 ![deploy_ref_10_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_10_2018.png)
 
+<a id="functional-description"></a>
+
 ## Functional Description 
 
 Here, more fundtions that are not described in Getting Started, are described in details, along with additional settings. 
 
+<a id="binary"></a>
+
 ### Binary
 
 Binaries are uploaded files that are to be deployed.
+
+<a id="uploading"></a>
 
 #### Uploading 
 
@@ -194,9 +232,13 @@ Two methods are available to upload binaries:
 
 ![deploy_ref_12_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_12_2018.png)
 
+<a id="download"></a>
+
 #### 1. Download 
 
 Click Download on the right of the list. 
+
+<a id="fix-versions"></a>
 
 #### 2. Fix Versions 
 
@@ -207,6 +249,8 @@ Each client OS allows one version to be fixed.
         * Click to unfix the version. 
     * <span style="color:gray">FIXED</span>(off)
         * Click to fix the version. 
+
+<a id="deploy"></a>
 
 #### 3. Deploy 
 
@@ -244,6 +288,8 @@ Download page for particular binaries can be sent via SMS or email.
 
 Binary download page is sent to recipients in a specified type of delivery. 
 
+<a id="tasks"></a>
+
 ### Tasks 
 
 A task is a scenario configuration element which executes individual tasks and controls the order. 
@@ -271,6 +317,8 @@ A task is a scenario configuration element which executes individual tasks and c
 * Tasks can be controlled with ∧** (Upwards), **∨** (Downwards), or **X** (RemoveTask) buttons located on the right of each task. 
 * Reserved Words 
     * Find more details on Available Variables, as below.
+
+<a id="pre-run-tasks"></a>
 
 #### Pre-run Tasks
 
@@ -333,6 +381,8 @@ A task is a scenario configuration element which executes individual tasks and c
 * Command
     * Enter commands to run. 
     * Reserved words are available. See Available Variables, as below.  
+
+<a id="normal-tasks"></a>
 
 #### Normal Tasks
 
@@ -412,6 +462,8 @@ A task is a scenario configuration element which executes individual tasks and c
     * You may use Available Variables.
         * `$${binary.Enter specified Variables As.binaryGroupName}: Name of binary group selected as variable name set for a binary`
 
+<a id="available-variables"></a>
+
 #### Available Variables
 
 Reserved words as below are available for tasks: 
@@ -444,6 +496,8 @@ $${binary.binary variable as value.binaryGroupName}: Binary group name selected 
     * Types for Variable As of Binary Deploy
         * `$${binary.Enter specified Variables As.binaryGroupName}: Name of binary group`
 
+<a id="resources-2"></a>
+
 ### Resources 
 
 Resources refer to optional file management functions.  
@@ -454,6 +508,8 @@ Resources refer to optional file management functions.
 * File History
 * Manage File History 
 
+<a id="creating-file-groups"></a>
+
 #### Creating File Groups 
 
 ![deploy_ref_21_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_21_2018.png)
@@ -462,6 +518,8 @@ Resources refer to optional file management functions.
 
 2. Enter name (required) and description (optional). 
 3. Click **Confirm**.
+
+<a id="adding-files"></a>
 
 #### Adding Files 
 
@@ -485,6 +543,8 @@ If a file name is redundant in a file group, it cannot be properly uploaded.
 4. Fill in information for a new file. 
 5. When it is completed, click **Save**. 
 6. It is newly created. 
+
+<a id="modifying-files"></a>
 
 #### Modifying Files 
 

--- a/ja/reference.md
+++ b/ja/reference.md
@@ -5,14 +5,20 @@
 * [メニュー説明](/Dev%20Tools/Deploy/ja/reference/#_1)
 * [機能別説明](/Dev%20Tools/Deploy/ja/reference/#_18)
 
+<a id="menu-description"></a>
+
 ## メニュー説明
 
 ![deploy_ref_01_ja_20200527](https://static.toastoven.net/prod_tcdeploy/ja/deploy_ref_01_ja_20200527.png)
+
+<a id="artifact-menu"></a>
 
 ### 1. アーティファクトメニュー領域
 
 デプロイを管理するDeploy構成の基本単位です。
 作成されたアーティファクトは、画面上部にリスト形式で表示されます。
+
+<a id="deployment-menu"></a>
 
 ### 2. デプロイメニュー領域
 
@@ -28,6 +34,8 @@
 * サーバーグループとシナリオを選択してデプロイ
 * サーバーグループ内サーバー同時/個別デプロイ
 * デプロイノートにデプロイ詳細内容を入力すると、**デプロイ履歴**タブのデプロイ別結果参照ウィンドウで確認できます。 
+
+<a id="deployment-option"></a>
 
 #### デプロイオプション
 
@@ -57,6 +65,8 @@
 * **無中断**
     * エラーの有無に関係なく、シナリオが継続して実行されます。
 
+<a id="view-current-deployment-status"></a>
+
 #### 進行中のデプロイ状態を確認
 
 デプロイ中のシナリオの進行状況を確認できます。
@@ -65,6 +75,8 @@
 
 * デプロイ中のアーティファクトをクリックし、表示されるヘッダで確認したいデプロイ項目をクリックします。
 * デプロイ履歴画面で'deploying'状態をクリックします。
+
+<a id="deployment-history"></a>
 
 ### デプロイ履歴
 デプロイ履歴とデプロイ設定、デプロイノートの詳細な内容を確認できます。
@@ -93,6 +105,8 @@
     * **バイナリファイルがない履歴を除外**を選択して**ダウンロード**をクリックした時
     ![deploy_ref_06_2021.png](https://static.toastoven.net/prod_tcdeploy/reference/deploy_ref_06_2021.png)
     
+<a id="binary-group"></a>
+
 ### バイナリグループ
 
 **バイナリグループ**タブでは、バイナリをグループで管理できます。
@@ -109,6 +123,8 @@ Develop、Staging、Productなどのサーバー機器にデプロイされる�
 * 自動削除設定に該当バイナリグループの自動削除ポリシーを設定できます。
     * 自動削除設定の各項目を空の値にしてバイナリグループを作成した場合、自動削除設定は適用されません。
 
+<a id="server-group"></a>
+
 ### サーバーグループ
 
 デプロイ対象サーバーをグループで管理できます。
@@ -119,6 +135,8 @@ Auto Scaleサービスのインスタンス拡張に応じてデプロイ設定�
 * グループ、サーバー情報を修正できます。
 * グループで使用するシナリオを設定できます。
 
+<a id="adding-server-group"></a>
+
 #### サーバーグループ追加
 
 ![deploy_ref_08_ja_20200527.png](https://static.toastoven.net/prod_tcdeploy/ja/deploy_ref_08_ja_20200527.png)
@@ -128,6 +146,8 @@ Auto Scaleサービスのインスタンス拡張に応じてデプロイ設定�
     * OSを選択した後、Shell Typeを指定します。リストから項目を選択するか、直接入力します。
     * Phaseを選択します。サーバー機器を区分します。指定しない時はNONEを選択します。
     * **作成**ボタンをクリックします。
+
+<a id="addingdeleting-server-information"></a>
 
 #### サーバー情報追加/削除
 
@@ -163,6 +183,8 @@ Auto Scaleサービスのインスタンス拡張に応じてデプロイ設定�
 * 左にあるチェックボックスを選択解除するか、右にある**削除**ボタンをクリックします。
 * **作成**ボタンをクリックします。修正する時は**修正**ボタンをクリックします。
 
+<a id="auto-scale-group-addition"></a>
+
 #### オートスケール グループ追加
 ![autoscale_01.png](https://static.toastoven.net/prod_tcdeploy/reference/autoscale_01.png)
 * **デプロイ** > **サーバーグループ作成**をクリックするか、**サーバーグループ > 新規作成**
@@ -184,19 +206,27 @@ Auto Scaleサービスのインスタンス拡張に応じてデプロイ設定�
 * 追加されたシナリオ順序を指定するために実行優先順位を変更します。優先順位が同じ場合、ランダムな順序で実行されます。
 * **作成**ボタンをクリックします。 
 
+<a id="resources"></a>
+
 ### リソース
 
 リソースを管理できるページで、ファイル作成、アップロード、ダウンロード、修正や変更履歴の確認ができます。
 
 ![deploy_ref_10_ja_20200527.png](https://static.toastoven.net/prod_tcdeploy/ja/deploy_ref_10_ja_20200527.png)
 
+<a id="functional-description"></a>
+
 ## 機能別説明
 
 ここでは、Getting Startedで扱わない機能と追加設定を詳しく説明します。
 
+<a id="binary"></a>
+
 ### バイナリ
 
 バイナリは、アップロードされたデプロイ対象ファイルです。
+
+<a id="uploading"></a>
 
 #### アップロード
 
@@ -215,9 +245,13 @@ Auto Scaleサービスのインスタンス拡張に応じてデプロイ設定�
 
 ![deploy_ref_12_ja_20200527.png](https://static.toastoven.net/prod_tcdeploy/ja/deploy_ref_12_ja_20200527.png)
 
+<a id="download"></a>
+
 #### 1. ダウンロード
 
 バイナリリスト右にあるダウンロードボタンをクリックします。
+
+<a id="fix-versions"></a>
 
 #### 2. バージョンfix
 
@@ -228,6 +262,8 @@ Client OSごとに、1個ずつバージョンfixができます。
         * クリックすると、該当バージョンをunfixします。
     * <span style="color:gray">FIXED</span>(off)
         * クリックすると該当バージョンをfixします。
+
+<a id="deploy"></a>
 
 #### 3. デプロイ
 
@@ -265,6 +301,8 @@ ClientバイナリのAll、Fixed、Recentバージョンを、希望する方式
 
 指定した送信タイプで受信者にバイナリダウンロードページが伝達されます。
 
+<a id="tasks"></a>
+
 ### タスク
 
 タスクは、個別機能の実行および順序制御が可能なシナリオ構成要素です。
@@ -292,6 +330,8 @@ ClientバイナリのAll、Fixed、Recentバージョンを、希望する方式
 * 各タスクの右上にある**∧**(上に移動)**∨**(下に移動)**X**(Task除去)ボタンで、タスクを制御できます。
 * 予約語の使用
     * 詳細は下記Available Variablesを参照してください。
+
+<a id="pre-run-tasks"></a>
 
 #### Pre-run Task
 
@@ -354,6 +394,8 @@ ClientバイナリのAll、Fixed、Recentバージョンを、希望する方式
 * Command
     * 実行するCommandを入力します。
     * 予約語を使用できます。下記のAvailable Variablesメニューを参照してください。
+
+<a id="normal-tasks"></a>
 
 #### Normal Task
 
@@ -433,6 +475,8 @@ ClientバイナリのAll、Fixed、Recentバージョンを、希望する方式
     * Available Variablesを使用できます。
         * `$${binary.指定したVariables As入力。binaryGroupName}：バイナリに設定した変数名。選択されたバイナリのグループ名`
 
+<a id="available-variables"></a>
+
 #### Available Variables
 
 タスクで下記のような予約語を使用できます。
@@ -465,6 +509,8 @@ $${binary.binary variable as value.binaryGroupName}：バイナリに設定し�
     * Binary DeployのVariables Asを使用できるタイプ
         * `$${binary.指定したVariables As入力.binaryGroupName}：該当バイナリのグループ名`
 
+<a id="resources-2"></a>
+
 ### リソース
 
 リソースは任意で使用できるファイル管理機能です。
@@ -475,6 +521,8 @@ $${binary.binary variable as value.binaryGroupName}：バイナリに設定し�
 * ファイルヒストリー
 * ファイル履歴管理
 
+<a id="creating-file-groups"></a>
+
 #### ファイルグループ作成
 
 ![deploy_ref_21_ja_20200527.png](https://static.toastoven.net/prod_tcdeploy/ja/deploy_ref_21_ja_20200527.png)
@@ -483,6 +531,8 @@ $${binary.binary variable as value.binaryGroupName}：バイナリに設定し�
 
 2. 名前(必須)、説明(任意)情報を入力します。
 3. **確認**ボタンをクリックします。
+
+<a id="adding-files"></a>
 
 #### ファイル追加
 
@@ -506,6 +556,8 @@ $${binary.binary variable as value.binaryGroupName}：バイナリに設定し�
 4. 新規作成ファイルの内容を入力します。
 5. 入力完了後、**保存**ボタンをクリックします。
 6. 作成が完了した画面です。
+
+<a id="modifying-files"></a>
 
 #### ファイル修正
 

--- a/ko/reference.md
+++ b/ko/reference.md
@@ -5,14 +5,20 @@
 * [메뉴 설명](/Dev%20Tools/Deploy/ko/reference/#_1)
 * [기능별 설명](/Dev%20Tools/Deploy/ko/reference/#_18)
 
+<a id="menu-description"></a>
+
 ## 메뉴 설명
 
 ![deploy_ref_01_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_01_2018.png)
+
+<a id="artifact-menu"></a>
 
 ### 1. 아티팩트 메뉴 영역
 
 배포를 관리하는 Deploy 구성의 기본 단위입니다.
 생성된 아티팩트는 화면 위쪽에 목록 형태로 표시됩니다.
+
+<a id="deployment-menu"></a>
 
 ### 2. 배포 메뉴 영역
 
@@ -28,6 +34,8 @@
 * 서버 그룹과 시나리오를 선택해 배포
 * 서버 그룹 내 서버 동시/개별 배포
 * 배포 노트에 배포 상세 내용을 입력하면, **배포 이력** 탭의 배포별 결과 보기 창에서 확인할 수 있습니다. 
+
+<a id="deployment-option"></a>
 
 #### 배포 옵션
 
@@ -57,6 +65,8 @@
 * **무중단**
     * 오류 여부와 관계없이 시나리오가 계속 실행됩니다.
 
+<a id="view-current-deployment-status"></a>
+
 #### 진행 중인 배포 상태 보기 
 
 배포 중인 시나리오의 진행 상황을 확인할 수 있습니다.
@@ -65,6 +75,8 @@
 
 * 배포 중인 아티팩트를 클릭하면 나타나는 헤더에서 확인하고자 하는 배포 항목을 클릭합니다.
 * 배포 이력 화면에서 'deploying' 상태를 클릭합니다.
+
+<a id="deployment-history"></a>
 
 ### 배포 이력
 배포 이력과 배포 설정, 배포 노트의 자세한 내용을 확인할 수 있습니다.
@@ -93,6 +105,8 @@
     * **바이너리 파일 없는 이력 제외** 선택 후 **다운로드** 클릭 시
     ![deploy_ref_06_2021.png](https://static.toastoven.net/prod_tcdeploy/reference/deploy_ref_06_2021.png)
     
+<a id="binary-group"></a>
+
 ### 바이너리 그룹
 
 **바이너리 그룹** 탭에서는 바이너리를 그룹으로 관리할 수 있습니다.
@@ -109,6 +123,8 @@ Develop, Staging, Product 등의 서버 장비에 배포되는 바이너리를 �
 * 자동 삭제 설정에 해당 바이너리 그룹의 자동 삭제 정책을 설정할 수 있습니다.
     * 자동 삭제 설정의 각 항목을 빈값으로 두고 바이너리 그룹을 생성할 경우 자동 삭제 설정이 적용되지 않습니다.
 
+<a id="server-group"></a>
+
 ### 서버 그룹
 
 배포 대상 서버를 그룹으로 관리할 수 있습니다.
@@ -119,6 +135,8 @@ Auto Scale 서비스의 인스턴스 확장에 따른 배포를 설정할 수 �
 * 그룹, 서버 정보를 수정할 수 있습니다.
 * 그룹에서 사용할 시나리오를 설정할 수 있습니다.
 
+<a id="adding-server-group"></a>
+
 #### 서버 그룹 추가
 
 ![deploy_ref_08_202402.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_08_202402.png)
@@ -128,6 +146,8 @@ Auto Scale 서비스의 인스턴스 확장에 따른 배포를 설정할 수 �
     * OS를 선택한 후 Shell Type를 지정합니다. 목록에서 항목을 선택하거나 직접 입력할 수 있습니다.
     * Phase를 선택합니다. 서버 장비를 구분합니다. 지정하지 않으려면 NONE을 선택합니다.
     * **생성** 버튼을 클릭합니다.
+
+<a id="addingdeleting-server-information"></a>
 
 #### 서버 정보 추가/삭제
 
@@ -163,6 +183,8 @@ Auto Scale 서비스의 인스턴스 확장에 따른 배포를 설정할 수 �
 * 삭제할 서버를 선택하여 우측 상단의  **선택 삭제** 버튼을 클릭합니다.
 * **생성** 버튼을 클릭합니다. 수정할 때는 **수정** 버튼을 클릭합니다.
 
+<a id="auto-scale-group-addition"></a>
+
 #### 오토 스케일 그룹 추가
 ![autoscale_01.png](https://static.toastoven.net/prod_tcdeploy/reference/autoscale_01.png)
 * **배포** > **서버 그룹 생성**을 클릭하거나, **서버 그룹 > 새로 만들기**
@@ -184,19 +206,27 @@ Auto Scale 서비스의 인스턴스 확장에 따른 배포를 설정할 수 �
 * 추가된 시나리오 순서를 지정하기 위해 실행 우선순위를 변경합니다. 우선순위가 같으면 무작위 순서로 실행됩니다.
 * **생성** 버튼을 클릭합니다. 
 
+<a id="resources"></a>
+
 ### 리소스
 
 리소스를 관리할 수 있는 페이지로, 파일 생성, 업로드, 다운로드, 수정을 할 수 있으며 변경 이력을 확인할 수 있습니다.
 
 ![deploy_ref_10_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_10_2018.png)
 
+<a id="functional-description"></a>
+
 ## 기능별 설명
 
 여기에서는 Getting Started에서 다루지 않은 기능과 추가 설정을 자세히 설명합니다.
 
+<a id="binary"></a>
+
 ### 바이너리
 
 바이너리는 업로드된 배포 대상 파일입니다.
+
+<a id="uploading"></a>
 
 #### 업로드
 
@@ -215,9 +245,13 @@ Auto Scale 서비스의 인스턴스 확장에 따른 배포를 설정할 수 �
 
 ![deploy_ref_12_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_12_2018.png)
 
+<a id="download"></a>
+
 #### 1. 다운로드
 
 바이너리 목록 오른쪽의 다운로드 버튼을 클릭합니다.
+
+<a id="fix-versions"></a>
 
 #### 2. 버전 픽스
 
@@ -228,6 +262,8 @@ Client OS별 1개씩 버전 픽스를 할 수 있습니다.
         * 클릭 시 해당 버전을 unfix합니다.
     * <span style="color:gray">FIXED</span>(off)
         * 클릭 시 해당 버전을 fix합니다.
+
+<a id="deploy"></a>
 
 #### 3. 배포
 
@@ -265,6 +301,8 @@ Client 바이너리의 All, Fixed, Recent 버전을 원하는 방식으로 배�
 
 지정한 전송 유형으로 수신자에게 바이너리 다운로드 페이지가 전달됩니다.
 
+<a id="tasks"></a>
+
 ### 태스크
 
 태스크는 개별 기능 수행 및 순서 제어가 가능한 시나리오 구성 요소 입니다.
@@ -292,6 +330,8 @@ Client 바이너리의 All, Fixed, Recent 버전을 원하는 방식으로 배�
 * 각 태스크 오른쪽 위에 있는 **∧** (위로 이동) **∨** (아래로 이동) **X** (Task 제거) 버튼으로 태스크를 제어할 수 있습니다.
 * 예약어 사용
     * 자세한 내용은 아래 Available Variables를 참고하시기 바랍니다.
+
+<a id="pre-run-tasks"></a>
 
 #### Pre-run Task
 
@@ -354,6 +394,8 @@ Client 바이너리의 All, Fixed, Recent 버전을 원하는 방식으로 배�
 * Command
     * 실행할 Command를 입력합니다.
     * 예약어를 사용할 수 있습니다. 아래 Available Variables 메뉴를 참고하세요.
+
+<a id="normal-tasks"></a>
 
 #### Normal Task
 
@@ -433,6 +475,8 @@ Client 바이너리의 All, Fixed, Recent 버전을 원하는 방식으로 배�
     * Available Variables를 사용할 수 있습니다.
         * `$${binary.지정한 Variables As 입력.binaryGroupName} : 바이너리에 설정한 변수 이름으로 선택된 바이너리의 그룹 이름`
 
+<a id="available-variables"></a>
+
 #### Available Variables
 
 태스크에서 아래와 같은 예약어를 사용할 수 있습니다.
@@ -465,6 +509,8 @@ $${binary.binary variable as value.binaryGroupName} : 바이너리에 설정한 
     * Binary Deploy의 Variables As을 사용할 수 있는 타입
         * `$${binary.지정한 Variables As 입력.binaryGroupName} : 해당 바이너리의 그룹 이름`
 
+<a id="resources-2"></a>
+
 ### 리소스
 
 리소스는 선택적으로 사용할 수 있는 파일 관리 기능입니다.
@@ -475,6 +521,8 @@ $${binary.binary variable as value.binaryGroupName} : 바이너리에 설정한 
 * 파일 히스토리
 * 파일 이력 관리
 
+<a id="creating-file-groups"></a>
+
 #### 파일 그룹 생성
 
 ![deploy_ref_21_2018.png](https://static.toastoven.net/prod_tcdeploy/deploy_ref_21_2018.png)
@@ -483,6 +531,8 @@ $${binary.binary variable as value.binaryGroupName} : 바이너리에 설정한 
 
 2. 이름(필수), 설명(선택) 정보를 입력합니다.
 3. **확인** 버튼을 클릭합니다.
+
+<a id="adding-files"></a>
 
 #### 파일 추가
 
@@ -506,6 +556,8 @@ $${binary.binary variable as value.binaryGroupName} : 바이너리에 설정한 
 4. 신규 생성 파일 내용을 입력합니다.
 5. 입력 완료 후 **저장** 버튼을 클릭합니다.
 6. 생성이 완료된 모습입니다.
+
+<a id="modifying-files"></a>
 
 #### 파일 수정
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `master` |
| Scope | 1 doc(s); 3 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/54/ |
| Generated | 2026-06-12T13:38:53 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`master`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FDeploy%2Fblob%2Fmaster%2Fko%2Freference.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FDeploy%2Fpull%2F215&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/reference.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/reference.md` | 0 | 2 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/reference.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Deploy`